### PR TITLE
feat(s3) : generatePresignedUrl할 때 key가 null이면 null반환 하도록 변경

### DIFF
--- a/src/main/java/com/bho/catchtrippingbackend/s3/service/S3Service.java
+++ b/src/main/java/com/bho/catchtrippingbackend/s3/service/S3Service.java
@@ -22,6 +22,9 @@ public class S3Service {
     private String bucket;
 
     public String generatePresignedUrl(String key, HttpMethod method) {
+        if (key == null || key.isEmpty()) {
+            return null;
+        }
         Date expiration = getExpiration();
 
         GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, key)


### PR DESCRIPTION
여기저기서 null을 확인하지 않아도 되도록
generatePresignedUrl 메서드 단에서 자체적으로 null을 걸러주도록 수정했습니다.